### PR TITLE
Add ObservationType to the base Observation class

### DIFF
--- a/src/Cos/Constants.cs
+++ b/src/Cos/Constants.cs
@@ -25,4 +25,15 @@ namespace Easee.Cos
         COS_OBS_TYPE_ASCII,
         COS_OBS_TYPE_UTF8,
     }
+
+    public enum ObservationType
+    {
+        Binary = 1,
+        Boolean = 2,
+        Double = 3,
+        Integer = 4,
+        Position = 5,
+        String = 6,
+        Statistics = 7
+    }
 }

--- a/src/Cos/CosReader.cs
+++ b/src/Cos/CosReader.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Cos.Exceptions;
+using Easee.Cos.Exceptions;
 
 namespace Easee.Cos
 {

--- a/src/Cos/CosWriter.cs
+++ b/src/Cos/CosWriter.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Cos.Exceptions;
+using Easee.Cos.Exceptions;
 
 namespace Easee.Cos
 {

--- a/src/Cos/Exceptions/UnsupportedCosVersionException.cs
+++ b/src/Cos/Exceptions/UnsupportedCosVersionException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Cos.Exceptions
+namespace Easee.Cos.Exceptions
 {
     public class UnsupportedCosVersionException : Exception
     {

--- a/src/Cos/Exceptions/UnsupportedObservationTypeException.cs
+++ b/src/Cos/Exceptions/UnsupportedObservationTypeException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Cos.Exceptions
+namespace Easee.Cos.Exceptions
 {
     public class UnsupportedObservationTypeException : ArgumentException
     {

--- a/src/Cos/Observation.cs
+++ b/src/Cos/Observation.cs
@@ -1,17 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using Easee.Cos.Exceptions;
 
 namespace Easee.Cos
 {
     public abstract class Observation : IComparable<Observation>
     {
-        public Observation(int observationId, DateTime timestamp)
+        public Observation(int observationId, DateTime timestamp, ObservationType type)
         {
             ObservationId = observationId;
+            Type = type;
             Timestamp = timestamp;
         }
 
         public int ObservationId { get; }
+        public ObservationType Type { get; }
         public DateTime Timestamp { get; }
 
         public override string ToString() => $"ID:{ObservationId}.";
@@ -22,7 +25,14 @@ namespace Easee.Cos
     public class Observation<TValue> : Observation
     {
         public Observation(int observationId, DateTime timestamp, TValue value)
-            : base(observationId, timestamp)
+            : base(observationId, timestamp, typeof(TValue) switch { 
+                Type i when i == typeof(int) => ObservationType.Integer,
+                Type d when d == typeof(double) => ObservationType.Double,
+                Type b when b == typeof(bool) => ObservationType.Boolean,
+                Type s when s == typeof(string) => ObservationType.String,
+                Type p when p == typeof(Position) => ObservationType.Position,
+                _ => throw new UnsupportedObservationTypeException(typeof(TValue).FullName),
+            })
         {
             Value = value;
         }
@@ -33,6 +43,7 @@ namespace Easee.Cos
         public override int CompareTo(Observation? other) {
             return (other is Observation<TValue> o
                 && o.ObservationId == ObservationId
+                && o.Type == Type
                 && o.Timestamp == Timestamp
                 && Comparer<TValue>.Default.Compare(Value, o.Value) == 0) 
                 ? 0 : 1;

--- a/src/Tests/Cos.Tests/CosReaderTests.cs
+++ b/src/Tests/Cos.Tests/CosReaderTests.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Cos.Exceptions;
+using Easee.Cos.Exceptions;
 using Xunit;
 
 namespace Cos.Tests

--- a/src/Tests/Cos.Tests/CosWriterTests.cs
+++ b/src/Tests/Cos.Tests/CosWriterTests.cs
@@ -1,6 +1,6 @@
 using Easee.Cos;
 using System;
-using Cos.Exceptions;
+using Easee.Cos.Exceptions;
 using Xunit;
 
 namespace Cos.Tests

--- a/src/Tests/Cos.Tests/ObservationTests.cs
+++ b/src/Tests/Cos.Tests/ObservationTests.cs
@@ -1,0 +1,44 @@
+﻿using Easee.Cos;
+using System;
+using Xunit;
+
+namespace Cos.Tests
+{
+    public class ObservationTests
+    {
+        [Fact]
+        public void Boolean_type()
+        {
+            var observation = new Observation<bool>(150, DateTime.UtcNow, true);
+            Assert.Equal(ObservationType.Boolean, observation.Type);
+        }
+
+        [Fact]
+        public void Double_type()
+        {
+            var observation = new Observation<double>(150, DateTime.UtcNow, 1.234);
+            Assert.Equal(ObservationType.Double, observation.Type);
+        }
+
+        [Fact]
+        public void Integer_type()
+        {
+            var observation = new Observation<int>(150, DateTime.UtcNow, 12);
+            Assert.Equal(ObservationType.Integer, observation.Type);
+        }
+
+        [Fact]
+        public void String_type()
+        {
+            var observation = new Observation<string>(150, DateTime.UtcNow, "hello world");
+            Assert.Equal(ObservationType.String, observation.Type);
+        }
+
+        [Fact]
+        public void Position_type()
+        {
+            var observation = new Observation<Position>(150, DateTime.UtcNow, new(59, 10));
+            Assert.Equal(ObservationType.Position, observation.Type);
+        }
+    }
+}


### PR DESCRIPTION
Currently we're copying the ObservationType enum around in lots of different projects. Let's maintain a single version at the source instead.

As a bonus this enables easier type identification.

Now you can simply do

    var type = observation.Type;

While previously you would have to do something like

    var type = observation switch  
    {  
        observation<int> => ObservationType.Integer,  
        observation<double> => ObservationType.Double,  
        observation<bool> => ObservationType.Boolean,  
        observation<string> => ObservationType.String,  
        observation<Position> => ObservationType.Position,  
        _ => throw new ArgumentException("Invalid observation type"),  
    }