### PR TITLE
Stream serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
           source-url: https://nuget.pkg.github.com/easee/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_READ_PAT_JANERIKFOSS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,11 @@ jobs:
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
           source-url: https://nuget.pkg.github.com/easee/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_READ_PAT_JANERIKFOSS }}

--- a/src/Cos/BigEndianBinaryReader.cs
+++ b/src/Cos/BigEndianBinaryReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 
 namespace Easee.Cos
 {
@@ -7,6 +8,11 @@ namespace Easee.Cos
     {
         public BigEndianBinaryReader(Stream stream)
             : base(stream)
+        {
+        }
+
+        public BigEndianBinaryReader(Stream stream, Encoding encoding, bool leaveOpen)
+            : base(stream, encoding, leaveOpen)
         {
         }
 

--- a/src/Cos/CosReader.cs
+++ b/src/Cos/CosReader.cs
@@ -18,8 +18,13 @@ namespace Easee.Cos
     {
         public List<Observation> Deserialize(in byte[] cosData)
         {
-            using MemoryStream stream = new(cosData);
-            using BigEndianBinaryReader reader = new(stream);
+            using var stream = new MemoryStream(cosData);
+            return Deserialize(stream);
+        }
+
+        public List<Observation> Deserialize(Stream stream)
+        {
+            using BigEndianBinaryReader reader = new(stream, Encoding.UTF8, true);
 
             byte cosVersion = reader.ReadByte();
             if (cosVersion == 1)

--- a/src/Cos/ICosReader.cs
+++ b/src/Cos/ICosReader.cs
@@ -1,10 +1,12 @@
 ﻿using Easee.IoT.DataTypes.Observations;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Easee.Cos
 {
     public interface ICosReader
     {
         List<Observation> Deserialize(in byte[] cosData);
+        List<Observation> Deserialize(Stream stream);
     }
 }

--- a/src/Tests/Cos.Benchmark/Cos.Benchmark.csproj
+++ b/src/Tests/Cos.Benchmark/Cos.Benchmark.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Cos.Benchmark/Program.cs
+++ b/src/Tests/Cos.Benchmark/Program.cs
@@ -3,9 +3,12 @@ using BenchmarkDotNet.Running;
 using Easee.IoT.DataTypes.Observations;
 using System;
 using System.Collections.Generic;
+using BenchmarkDotNet.Jobs;
 
 namespace Easee.Cos.Benchmark
 {
+    [SimpleJob(RuntimeMoniker.Net60, baseline: true)]
+    [SimpleJob(RuntimeMoniker.Net70)]
     [MemoryDiagnoser]
     public class CosDeserialize
     {


### PR DESCRIPTION
Kinesis records expose the data as streams. So it is natural to include an api which accepts streams.

I also added a comparison between dotnet 6 and 7 in the benchmarks. Microsoft optimized a lot of stream api's in dotnet 7, so we see some improvements.

AWS does not create native lambda runtimes for non LTS versions. So you need to create a custom runtime or run as an image in order to use dotnet 7 https://aws.amazon.com/blogs/compute/building-serverless-net-applications-on-aws-lambda-using-net-7/. So it is most likely no worth the hassle 

``` ini

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1105)
11th Gen Intel Core i7-11800H 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]   : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2
  .NET 6.0 : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT AVX2
  .NET 7.0 : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2


```
|                                Method |      Job |  Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|-------------------------------------- |--------- |--------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
|  DeserializePackageWithOneObservation | .NET 6.0 | .NET 6.0 |  3.253 μs | 0.0640 μs | 0.0598 μs |  1.00 |    0.00 | 0.2708 |   3.34 KB |        1.00 |
|  DeserializePackageWithOneObservation | .NET 7.0 | .NET 7.0 |  2.506 μs | 0.0537 μs | 0.1549 μs |  0.79 |    0.04 | 0.2556 |   3.17 KB |        0.95 |
|                                       |          |          |           |           |           |       |         |        |           |             |
| DeserializePackageWithTenObservations | .NET 6.0 | .NET 6.0 | 34.086 μs | 0.6580 μs | 1.8343 μs |  1.00 |    0.00 | 2.4414 |  30.04 KB |        1.00 |
| DeserializePackageWithTenObservations | .NET 7.0 | .NET 7.0 | 23.947 μs | 0.4731 μs | 1.0082 μs |  0.70 |    0.05 | 2.2888 |   28.4 KB |        0.95 |